### PR TITLE
Add patent search feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+The application includes a small Express backend used to query patent
+data from the USPTO PatentsView API. The results page displays recent
+patents for each competitor.
+
 ## Available Scripts
 
 In the project directory, you can run:
@@ -13,6 +17,13 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
+
+### `npm run server`
+
+Starts the small Express backend that proxies patent queries to the
+[PatentsView API](https://patentsview.org/apis/purpose). It listens on
+port `5000` and exposes an `/api/patents` route accepting a `company`
+query parameter.
 
 ### `npm test`
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.9.0",
+    "cors": "^2.8.5",
     "html2canvas": "^1.4.1",
+    "express": "^4.18.2",
     "jspdf": "^3.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -22,7 +24,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server.js
+++ b/server.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const axios = require('axios');
+const cors = require('cors');
+
+const app = express();
+const PORT = process.env.PORT || 5000;
+
+app.use(cors());
+app.use(express.json());
+
+const PATENT_API_URL = 'https://api.patentsview.org/patents/query';
+
+app.get('/api/patents', async (req, res) => {
+  const { company } = req.query;
+  if (!company) {
+    return res.status(400).json({ error: 'company query param required' });
+  }
+
+  try {
+    const query = { _text_any: { patent_title: company } };
+    const fields = ['patent_number', 'patent_title', 'patent_date'];
+
+    const response = await axios.get(PATENT_API_URL, {
+      params: {
+        q: JSON.stringify(query),
+        f: JSON.stringify(fields),
+        o: JSON.stringify({ per_page: 5 })
+      }
+    });
+
+    const patents = (response.data.patents || []).map(p => ({
+      number: p.patent_number,
+      title: p.patent_title,
+      date: p.patent_date
+    }));
+
+    res.json({ patents });
+  } catch (err) {
+    console.error('Error fetching patents:', err.message);
+    res.status(500).json({ error: 'Failed to fetch patents' });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/src/App.css
+++ b/src/App.css
@@ -919,6 +919,35 @@ button.secondary:hover {
   border-top: 1px solid #e2e8f0;
 }
 
+.competitor-patents {
+  margin-top: 16px;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 12px 16px;
+}
+
+.competitor-patents h4 {
+  margin: 0 0 8px 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.competitor-patents ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.competitor-patents li {
+  font-size: 0.95rem;
+  color: #475569;
+}
+
 .analysis-section {
   background: #f8fafc;
   border-radius: 10px;

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FiDownload, FiTrendingUp, FiTarget, FiUsers, FiCheckCircle, FiDollarSign, FiExternalLink, FiAlertCircle, FiLink, FiMessageSquare, FiCopy, FiClock, FiSave } from 'react-icons/fi';
 import jsPDF from 'jspdf';
@@ -13,6 +14,7 @@ const ResultsPage = () => {
   const [isSaving, setIsSaving] = useState(false);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState('');
+  const [patentData, setPatentData] = useState({});
 
   useEffect(() => {
     const fetchUser = async () => {
@@ -304,6 +306,26 @@ const ResultsPage = () => {
     return [];
   };
 
+  useEffect(() => {
+    const loadPatents = async () => {
+      const results = {};
+      for (const comp of competitors) {
+        if (!comp.name) continue;
+        try {
+          const res = await axios.get('http://localhost:5000/api/patents', {
+            params: { company: comp.name }
+          });
+          results[comp.name] = res.data.patents || [];
+        } catch (err) {
+          console.error('Patent fetch error', err);
+          results[comp.name] = [];
+        }
+      }
+      setPatentData(results);
+    };
+    if (competitors.length) loadPatents();
+  }, [competitors]);
+
   return (
     <div className="results-container">
       <a className="back-link" href="/validate">← Validate Another Idea</a>
@@ -402,6 +424,22 @@ const ResultsPage = () => {
                     ))}
                   </ul>
                 </div>
+              </div>
+              <div className="competitor-patents">
+                <h4>Recent Patents</h4>
+                {patentData[comp.name] && patentData[comp.name].length > 0 ? (
+                  <ul>
+                    {patentData[comp.name].map((p) => (
+                      <li key={p.number}>
+                        <a href={`https://patents.google.com/patent/${p.number}`} target="_blank" rel="noopener noreferrer">
+                          {p.title} ({p.date})
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>No patents found</p>
+                )}
               </div>
             </div>
           ))


### PR DESCRIPTION
## Summary
- add Express server with route to query USPTO's PatentsView API
- integrate competitor patent lookup in Results page
- style patent list on the results page
- document backend server usage

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ade05eac832b8ab7c9127a5b5480