### PR TITLE
Fix supabase auth hang

### DIFF
--- a/src/components/HomePage.js
+++ b/src/components/HomePage.js
@@ -10,7 +10,7 @@ const HomePage = () => {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setUser(data?.user || null));
+    supabase.auth.getSession().then(({ data }) => setUser(data.session?.user || null));
     const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user || null);
     });

--- a/src/components/PricingPage.js
+++ b/src/components/PricingPage.js
@@ -71,7 +71,8 @@ export default function PricingPage() {
   useEffect(() => {
     const getUserData = async () => {
       try {
-        const { data: { user } } = await supabase.auth.getUser();
+        const { data: { session } } = await supabase.auth.getSession();
+        const user = session?.user;
         if (user) {
           setUserEmail(user.email);
           setUserId(user.id);

--- a/src/components/ProfileDashboard.js
+++ b/src/components/ProfileDashboard.js
@@ -59,7 +59,7 @@ export default function ProfileDashboard() {
   const { getIdeaStorageLimit, userPlan } = useFeatureAccess();
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setUser(data?.user || null));
+    supabase.auth.getSession().then(({ data }) => setUser(data.session?.user || null));
   }, []);
 
   useEffect(() => {

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -79,16 +79,19 @@ const ResultsPage = () => {
     
     try {
 
-      console.log('Fetching user from Supabase...');
-      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
-      const freshUser = session?.user;
-      console.log('Fresh user:', freshUser);
-      console.log('Session error:', sessionError);
+      console.log('Fetching cached user...');
+      let freshUser = user;
 
-      if (sessionError) {
-        console.error('User authentication error:', sessionError);
-        setSaveError('Authentication error. Please log in again.');
-        return;
+      if (!freshUser) {
+        console.log('No cached user, attempting to retrieve session...');
+        const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+        if (sessionError) {
+          console.error('User authentication error:', sessionError);
+          setSaveError('Authentication error. Please log in again.');
+          return;
+        }
+        console.log('Session fetched:', session);
+        freshUser = session?.user;
       }
       
       if (!freshUser) {

--- a/src/components/ResultsPage.js
+++ b/src/components/ResultsPage.js
@@ -37,7 +37,8 @@ const ResultsPage = () => {
     const fetchUser = async () => {
       try {
         console.log('Fetching user in useEffect...');
-        const { data: { user }, error } = await supabase.auth.getUser();
+        const { data: { session }, error } = await supabase.auth.getSession();
+        const user = session?.user;
         console.log('User fetch result:', { user, error });
         
         if (error) {
@@ -79,12 +80,13 @@ const ResultsPage = () => {
     try {
 
       console.log('Fetching user from Supabase...');
-      const { data: { user: freshUser }, error: userError } = await supabase.auth.getUser();
+      const { data: { session }, error: sessionError } = await supabase.auth.getSession();
+      const freshUser = session?.user;
       console.log('Fresh user:', freshUser);
-      console.log('User error:', userError);
-      
-      if (userError) {
-        console.error('User authentication error:', userError);
+      console.log('Session error:', sessionError);
+
+      if (sessionError) {
+        console.error('User authentication error:', sessionError);
         setSaveError('Authentication error. Please log in again.');
         return;
       }

--- a/src/components/ValidatePage.js
+++ b/src/components/ValidatePage.js
@@ -61,7 +61,8 @@ const ValidatePage = () => {
   useEffect(() => {
     const fetchUserProfile = async () => {
       try {
-        const { data: { user } } = await supabase.auth.getUser();
+        const { data: { session } } = await supabase.auth.getSession();
+        const user = session?.user;
         if (user) {
           const { data: profileData } = await supabase
             .from('profiles')

--- a/src/hooks/useFeatureAccess.js
+++ b/src/hooks/useFeatureAccess.js
@@ -23,7 +23,8 @@ export const useFeatureAccess = () => {
   useEffect(() => {
     // Get current user
     const getUser = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
+      const { data: { session } } = await supabase.auth.getSession();
+      const user = session?.user;
       setUser(user);
       
       if (user) {

--- a/src/reusable/Navbar.js
+++ b/src/reusable/Navbar.js
@@ -9,7 +9,7 @@ const Navbar = () => {
   const [user, setUser] = useState(null);
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setUser(data?.user || null));
+    supabase.auth.getSession().then(({ data }) => setUser(data.session?.user || null));
     const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
       setUser(session?.user || null);
     });


### PR DESCRIPTION
## Summary
- use `getSession()` instead of `getUser()` everywhere to avoid stalled network calls
- extract the user from the returned session object

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68729fcbdba4832b90911592c53f2242